### PR TITLE
Allow grouping of artist releases by release type.

### DIFF
--- a/API/Common.pm
+++ b/API/Common.pm
@@ -152,7 +152,7 @@ sub _precacheAlbum {
 	$albums = __PACKAGE__->filterPlayables($albums);
 
 	foreach my $album (@$albums) {
-		foreach (qw(composer duration articles article_ids catchline
+		foreach (qw(composer articles article_ids catchline
 			# maximum_bit_depth maximum_channel_count maximum_sampling_rate maximum_technical_specifications
 			popularity previewable qobuz_id sampleable slug streamable_at subtitle created_at
 			product_type product_url purchasable purchasable_at relative_url release_date_download release_date_original

--- a/HTML/EN/plugins/Qobuz/settings/basic.html
+++ b/HTML/EN/plugins/Qobuz/settings/basic.html
@@ -69,6 +69,11 @@
 			</select>
 		[% END %]
 
+		[% WRAPPER settingGroup title="PLUGIN_QOBUZ_GROUP_RELEASES" desc="" %]
+			<input type="checkbox" [% IF prefs.pref_groupReleases %]checked [% END %] class="stdedit" name="pref_groupReleases" id="pref_groupReleases" value="1" />
+			<label for="pref_groupReleases" class="stdlabel">[% "PLUGIN_QOBUZ_GROUP_RELEASES_DESC" | string %]</label>
+		[% END %]
+
 		[% WRAPPER settingGroup title="PLUGIN_QOBUZ_SHOW_VERSION_WITH_TITLE" desc="" %]
 			<select name="pref_appendVersionToTitle" id="appendVersionToTitle">
 				<option [% prefs.appendVersionToTitle ? "selected" : "" %] value="1" >[% "YES" | string %]</option>

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -620,16 +620,23 @@ sub QobuzArtist {
 		# use album list if it was returned in the artist lookup
 		if ($artist->{albums}) {
 			my $albums = [];
-
+			my $numAlbums = 0;
+			my $numEps = 0;
+			my $numSingles = 0;
+			
 			# group by release type if requested
 			if ($groupByReleaseType) {
 				for my $album ( @{$artist->{albums}->{items}} ) {
+					next if $args->{artistId} && $album->{artist}->{id} != $args->{artistId};					
 					if ($album->{duration} >= 1800 || $album->{tracks_count} > 6) {
 						$album->{release_type} = "Album";
+						$numAlbums++;
 					} elsif ($album->{tracks_count} < 4) {
 						$album->{release_type} = "Single";
+						$numSingles++;
 					} else {
 						$album->{release_type} = "Ep";
+						$numEps++;
 					}
 				}
 			}
@@ -655,19 +662,23 @@ sub QobuzArtist {
 				if ($album->{release_type} ne $lastReleaseType) {
 					$lastReleaseType = $album->{release_type};
 					my $relType = "";
+					my $relNum = 0;
 					if ($lastReleaseType eq "Album") {
 						$relType = cstring($client, 'ALBUMS');
+						$relNum = $numAlbums;
 					} elsif ($lastReleaseType eq "Ep") {
 						$relType = cstring($client, 'RELEASE_TYPE_EPS');
+						$relNum = $numEps;
 					} elsif ($lastReleaseType eq "Single") {
 						$relType = cstring($client, 'RELEASE_TYPE_SINGLES');
+						$relNum = $numSingles;
 					} else {
 						$relType = "Unknown";  #should never occur
 					}
 
 					push @$albums, {
-						name => "*** $relType ***",
-						type => 'text',
+						name => "$relType ($relNum)",
+						image => 'html/images/albums.png',					
 					} ;
 				}
 				push @$albums, _albumItem($client, $album);

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -666,9 +666,8 @@ sub QobuzArtist {
 					}
 
 					push @$albums, {
-						name => $relType,
-						image => 'html/images/albums.png',
-						type => 'text'
+						name => "*** $relType ***",
+						type => 'text',
 					} ;
 				}
 				push @$albums, _albumItem($client, $album);

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -22,6 +22,10 @@ use constant CAN_IMPORTER => (Slim::Utils::Versions->compareVersions($::VERSION,
 use constant CLICOMMAND => 'qobuzquery';
 use constant MAX_RECENT => 30;
 
+use constant ALBUM => '1';
+use constant EP => '2';
+use constant SINGLE => '3';
+
 # Keep in sync with Music & Artist Information plugin
 my $WEBLINK_SUPPORTED_UA_RE = qr/\b(?:iPeng|SqueezePad|OrangeSqueeze|OpenSqueeze|Squeezer|Squeeze-Control)\b/i;
 my $WEBBROWSER_UA_RE = qr/\b(?:FireFox|Chrome|Safari)\b/i;
@@ -629,13 +633,13 @@ sub QobuzArtist {
 				for my $album ( @{$artist->{albums}->{items}} ) {
 					next if $args->{artistId} && $album->{artist}->{id} != $args->{artistId};					
 					if ($album->{duration} >= 1800 || $album->{tracks_count} > 6) {
-						$album->{release_type} = "Album";
+						$album->{release_type} = ALBUM;
 						$numAlbums++;
 					} elsif ($album->{tracks_count} < 4) {
-						$album->{release_type} = "Single";
+						$album->{release_type} = SINGLE;
 						$numSingles++;
 					} else {
-						$album->{release_type} = "Ep";
+						$album->{release_type} = EP;
 						$numEps++;
 					}
 				}
@@ -663,13 +667,13 @@ sub QobuzArtist {
 					$lastReleaseType = $album->{release_type};
 					my $relType = "";
 					my $relNum = 0;
-					if ($lastReleaseType eq "Album") {
+					if ($lastReleaseType eq ALBUM) {
 						$relType = cstring($client, 'ALBUMS');
 						$relNum = $numAlbums;
-					} elsif ($lastReleaseType eq "Ep") {
+					} elsif ($lastReleaseType eq EP) {
 						$relType = cstring($client, 'RELEASE_TYPE_EPS');
 						$relNum = $numEps;
-					} elsif ($lastReleaseType eq "Single") {
+					} elsif ($lastReleaseType eq SINGLE) {
 						$relType = cstring($client, 'RELEASE_TYPE_SINGLES');
 						$relNum = $numSingles;
 					} else {

--- a/Settings.pm
+++ b/Settings.pm
@@ -22,7 +22,7 @@ sub page {
 sub prefs {
 	return ($prefs, 'filterSearchResults', 'playSamples', 'showComposerWithArtist', 'labelHiResAlbums', 'dontImportPurchases',
 			'appendVersionToTitle', 'sortFavsAlphabetically', 'sortArtistAlbums', 'showYearWithAlbum', 'useClassicalEnhancements',
-			'classicalGenres', 'workPlaylistPosition', 'parentalWarning', 'showDiscs', 'preferredFormat');
+			'classicalGenres', 'workPlaylistPosition', 'parentalWarning', 'showDiscs', 'preferredFormat', 'groupReleases');
 }
 
 sub handler {

--- a/strings.txt
+++ b/strings.txt
@@ -540,6 +540,20 @@ PLUGIN_QOBUZ_SHOW_DISCS_DESC
 	NL	Heeft geen effect wanneer klassieke verbeteringen (zie hieronder) in gebruik zijn en er werken zijn geïdentificeerd
 	ES	No tiene efecto cuando se utilizan mejoras clásicas (ver más abajo) y se han identificado obras clásicas
 
+PLUGIN_QOBUZ_GROUP_RELEASES
+	DE	Gruppieren Sie Künstlerveröffentlichungen nach Typ
+	EN	Group artist releases by type
+	FR	Regrouper les sorties d'artistes par type
+	NL	Groepeer releases van artiesten op type
+	ES	Lanzamientos de artistas grupales por tipo
+
+PLUGIN_QOBUZ_GROUP_RELEASES_DESC
+	DE	Gruppieren Sie Künstlerveröffentlichungen nach Typ, wie von Spotify und iTunes definiert: d. h. Alben, EPs und Singles
+	EN	Group artist releases by type, as defined by Spotify and iTunes: i.e. Albums, EPs and Singles
+	FR	Regroupez les sorties d'artistes par type, tel que défini par Spotify et iTunes : c'est-à-dire albums, EP et singles.
+	NL	Groepeer releases van artiesten op type, zoals gedefinieerd door Spotify en iTunes: dat wil zeggen albums, EP's en singles
+	ES	Lanzamientos de artistas grupales por tipo, según lo definido por Spotify e iTunes: es decir, álbumes, EP y sencillos.
+
 PLUGIN_QOBUZ_TRACKS_LC
 	DE	Titel
 	EN	tracks
@@ -561,3 +575,8 @@ PLUGIN_QOBUZ_WORK
 	NL	Werk
 	ES	Composición
 
+PLUGIN_QOBUZ_RELEASE_TYPE
+	EN	Qobuz Release Type
+
+PLUGIN_QOBUZ_RELEASES
+	EN	Releases

--- a/strings.txt
+++ b/strings.txt
@@ -548,7 +548,7 @@ PLUGIN_QOBUZ_GROUP_RELEASES
 	ES	Lanzamientos de artistas grupales por tipo
 
 PLUGIN_QOBUZ_GROUP_RELEASES_DESC
-	DE	Gruppieren Sie Künstlerveröffentlichungen nach Typ, wie von Spotify und iTunes definiert: d. h. Alben, EPs und Singles
+	DE	Nach Veröffentlichungstyp gruppieren, wie von Spotify und iTunes definiert: d. h. Alben, EPs und Singles
 	EN	Group artist releases by type, as defined by Spotify and iTunes: i.e. Albums, EPs and Singles
 	FR	Regroupez les sorties d'artistes par type, tel que défini par Spotify et iTunes : c'est-à-dire albums, EP et singles.
 	NL	Groepeer releases van artiesten op type, zoals gedefinieerd door Spotify en iTunes: dat wil zeggen albums, EP's en singles


### PR DESCRIPTION
This is a change I have been wanting to make for a long time. It adds an option to group releases for an artist by release type, as defined by the iTunes and Spotify standards. With the option in effect, each release is classified as either an Album, EP or Single and grouped under one of those three headings. The order of the groups is not configurable.  However, the releases within each group will be sorted as specified in the Sort Artist Albums option. For comparison purposes, and to avoid confusion with Qobuz's somewhat random release typing, the Qobuz release type is now displayed in the Album Info page following the Genre, and is labeled as "Qobuz Release Type". All string translations are straight from Google Translate as I am monolingual. 