### PR TITLE
Correction of bug in playlist import: see issue #77

### DIFF
--- a/API/Sync.pm
+++ b/API/Sync.pm
@@ -120,7 +120,7 @@ sub myPlaylists {
 
 	my $playlists = $class->_get('playlist/getUserPlaylists', $userId, {
 		# TODO - need to pass the userId or configuration
-		username => Plugins::Qobuz::API::Common->username,
+		username => Plugins::Qobuz::API::Common->username($userId),
 		limit    => QOBUZ_DEFAULT_LIMIT,
 		_ttl     => QOBUZ_USER_DATA_EXPIRY,
 		_user_cache => 1,


### PR DESCRIPTION
Calling `Plugins::Qobuz::API::Common->username` without a parameter was screwing up the `$params` hash passed to `_get.` The username doesn't seem to be needed, but this is how it's done in `Plugin.pm`, so just replicating.