### PR TITLE
Only populate the Track Artist attribute for Main artists.

### DIFF
--- a/API/Common.pm
+++ b/API/Common.pm
@@ -131,7 +131,11 @@ sub username {
 sub getArtistName {
 	my ($class, $track, $album) = @_;
 	$track->{performer} ||= $album->{performer} || {};
-	return $track->{performer}->{name} || $album->{artist}->{name} || '',
+	if ($track->{performer} && $class->trackPerformerIsMainArtist($track) ) {
+		return $track->{performer}->{name};
+	} else {
+		return $album->{artist}->{name} || '';
+	}
 }
 
 sub filterPlayables {
@@ -324,6 +328,19 @@ sub getMainArtists {
 		}
 	}
 	return @artistList;
+}
+
+sub trackPerformerIsMainArtist {
+	my ($class, $track) = @_;
+	
+	if ($track->{performers}) {
+		my $pname = $track->{performer}->{name};
+		$pname =~ s/\s+$//;   # trim the trailing white space
+		return $track->{performers} =~ m/$pname([^\-]*)(Main\ ?Artist)/i;
+	}
+	else {
+		return 0;
+	}
 }
 
 sub getStreamingFormat {

--- a/Importer.pm
+++ b/Importer.pm
@@ -360,7 +360,7 @@ sub _prepareTrack {
 		}
 	}
 
-	if ($track->{performer} && $artist !~ m/(^|$_splitList)$track->{performer}->{name}($|$_splitList)/i
+	if ($track->{performer} && $artist !~ m/(^|\Q$_splitList\E)$track->{performer}->{name}($|\Q$_splitList\E)/i
 			&& Plugins::Qobuz::API::Common->trackPerformerIsMainArtist($track)) {
 		$attributes->{TRACKARTIST} = $track->{performer}->{name};
 	}

--- a/Importer.pm
+++ b/Importer.pm
@@ -315,7 +315,7 @@ sub _prepareTrack {
 	my $ct  = Slim::Music::Info::typeFromPath($url);
 
 	my ($artist, $artistId);
-	
+
 	my @artistList = Plugins::Qobuz::API::Common->getMainArtists($album);
 	$artist = join($_splitList, map { $_->{name} } @artistList);
 	$artistId = $artistList[0]->{id};   # Only add the primary artist id for now
@@ -360,7 +360,7 @@ sub _prepareTrack {
 		}
 	}
 
-	if ($track->{performer} && $track->{performer}->{name} ne $album->{artist}->{name} 
+	if ($track->{performer} && $artist !~ m/(^|$_splitList)$track->{performer}->{name}($|$_splitList)/i
 			&& Plugins::Qobuz::API::Common->trackPerformerIsMainArtist($track)) {
 		$attributes->{TRACKARTIST} = $track->{performer}->{name};
 	}

--- a/Importer.pm
+++ b/Importer.pm
@@ -360,7 +360,8 @@ sub _prepareTrack {
 		}
 	}
 
-	if ($track->{performer} && $track->{performer}->{name} ne $album->{artist}->{name}) {
+	if ($track->{performer} && $track->{performer}->{name} ne $album->{artist}->{name} 
+			&& Plugins::Qobuz::API::Common->trackPerformerIsMainArtist($track)) {
 		$attributes->{TRACKARTIST} = $track->{performer}->{name};
 	}
 


### PR DESCRIPTION
Only populate the Track Artist attribute for performers who are tagged as "MainArtist" or "Main Artist" in the $track->{performers} string. The purpose is to clean up the Track Artist attribute so that both the album artist and the track artist (if any) can be displayed consistently in track lists for all Qobuz releases, whether they come from the plugin or from the library.