### PR TITLE
Password encode UTF-8

### DIFF
--- a/Settings.pm
+++ b/Settings.pm
@@ -65,7 +65,7 @@ sub handler {
 
 		if ($params->{'username'} && $params->{'password'}) {
 			my $username = $params->{'username'};
-			my $password = md5_hex($params->{'password'});
+			my $password = md5_hex(Encode::encode("UTF-8", $params->{'password'}));
 
 			Plugins::Qobuz::API->login($username, $password, sub {
 				my $token = shift;


### PR DESCRIPTION
A user reported login failure: it turned out to be a "Wide Character" error because their password included the `€` symbol.

@michaelherger is this change fine with ancient Perl versions that might be in use?